### PR TITLE
fix area-select v-model can only be set once bug

### DIFF
--- a/components/area-select/index.vue
+++ b/components/area-select/index.vue
@@ -298,7 +298,7 @@
                 this.$nextTick(() => {
                     this.defaults = [];
                     // this.isCode = false;
-                    // this.isSetDefault = false;
+                    this.isSetDefault = false;
                 });
             },
 


### PR DESCRIPTION
now, the area-select v-model can only be init once.
I think it is a bug